### PR TITLE
Ruby 1.8.7 compatibility

### DIFF
--- a/lib/rubygems/nice_install/distro_guesser.rb
+++ b/lib/rubygems/nice_install/distro_guesser.rb
@@ -17,7 +17,7 @@ module Gem::Installer::Nice
 
     def self.distro_ext_installer
       require "rubygems/nice_install/#{distro}_ext_installer"
-      klass = Gem::Installer::Nice.const_get("#{distro.capitalize}ExtInstaller")
+      klass = Gem::Installer::Nice.const_get("#{distro.to_s.capitalize}ExtInstaller")
       klass.new if klass && klass != BaseExtInstaller
     end
 


### PR DESCRIPTION
Symbol doesn't have capitalize method defined in Ruby 1.8.7
