### PR TITLE
Explicitely require Gem::UserInteraction

### DIFF
--- a/lib/rubygems/nice_install.rb
+++ b/lib/rubygems/nice_install.rb
@@ -1,3 +1,4 @@
+require 'rubygems/user_interaction'
 
 module Gem
   pre_install do |gem_installer|


### PR DESCRIPTION
If I want to use gem-nice-install with Bundler, `Gem::UserInteraction` is not automatically required. This PR fixes it.
```
RUBYOPT="-rrubygems/nice_install" bundle
/home/strzibny/.gem/ruby/gems/gem-nice-install-0.2.0/lib/rubygems/nice_install/base_ext_installer.rb:4:in `<class:BaseExtInstaller>': uninitialized constant Gem::UserInteraction (NameError)
```
One have to use `RUBYOPT="-rrubygems/user_interaction -rrubygems/nice_install"` now which is not optimal.