### PR TITLE
Rescue getting DBus::SessionBus.instance when DISPLAY environment var…

### DIFF
--- a/lib/rubygems/nice_install/fedora_ext_installer.rb
+++ b/lib/rubygems/nice_install/fedora_ext_installer.rb
@@ -50,7 +50,10 @@ module Gem::Installer::Nice
         pkg_kit = session_bus.introspect("org.freedesktop.PackageKit", "/org/freedesktop/PackageKit")
         pkg_kit['org.freedesktop.PackageKit.Modify'].InstallPackageNames(0, names, 'show-confirm-install')
       # DBus is not availabe in non-X environment.
-      rescue Errno::ENOENT
+      #
+      # Rescue NoMethodError when DISPLAY env variable is not set.
+      # See https://github.com/mvidner/ruby-dbus/issues/53
+      rescue NoMethodError, Errno::ENOENT
         say "PackageKit failed. DBus activation failed."
         false
       rescue LoadError


### PR DESCRIPTION
…iable is not set

Related: https://github.com/mvidner/ruby-dbus/issues/53